### PR TITLE
Add view, no_streaming and multiple rics to edp/python

### DIFF
--- a/Applications/Examples/EDP/python/README.md
+++ b/Applications/Examples/EDP/python/README.md
@@ -52,10 +52,12 @@ Option            |Description|
 `--auth_url`      | OPTIONAL. URL of the EDP Gateway. Defaults to https://api.refinitiv.com:443/auth/oauth2/beta1/token.
 `--port`          | OPTIONAL. Port of the Elektron Real-Time Service. Defaults to 443.
 `--scope`         | OPTIONAL. An authorization scope to include when authenticating. Defaults to 'trapi'.
-`--ric`           | OPTIONAL. Name of the item to request from the Elektron Real-Time Service. If not specified, /TRI.N is requested.
+`--ric`          | OPTIONAL. Name of the item to request from the Elektron Real-Time Service. Can provide several rics if they are separated by comma (','). If not specified, /TRI.N is requested.
 `--app_id`        | OPTIONAL. Application ID to use when logging in. If not specified, "256" is used.
 `--position`      | OPTIONAL. Position to use when logging in. If not specified, the current host is used.
 `--service`       | OPTIONAL. The requested service name or service ID. Defaults to ELEKTRON_DD.
+`--view`         | OPTIONAL. List of fields to show, separated by comma (','). If not specified, all fields with be returned.
+`--no_streaming` | OPTIONAL. Returns only one response and doest not stream the new events.
 
 ### Running the market\_price\_edpgw\_service\_discovery Example
 
@@ -75,10 +77,12 @@ Option            |Description|
 `--discovery_url` | OPTIONAL. URL of the Service Discovery EDP Gateway. Defaults to https://api.refinitiv.com/streaming/pricing/v1/.
 `--scope`         | OPTIONAL. An authorization scope to include when authenticating. Defaults to 'trapi'.
 `--region`        | OPTIONAL. Specifies a region to get endpoint(s) from the service discovery. The region is either "amer" or "emea". Defaults to "amer".
-`--ric`           | OPTIONAL. Name of the item to request from the Elektron Real-Time Service. If not specified, /TRI.N is requested.
+`--ric`          | OPTIONAL. Name of the item to request from the Elektron Real-Time Service. Can provide several rics if they are separated by comma (','). If not specified, /TRI.N is requested.
 `--app_id`        | OPTIONAL. Application ID to use when logging in. If not specified, "256" is used.
 `--position`      | OPTIONAL. Position to use when logging in. If not specified, the current host is used.
 `--service`       | OPTIONAL. The requested service name or service ID. Defaults to ELEKTRON_DD.
+`--view`         | OPTIONAL. List of fields to show, separated by comma (','). If not specified, all fields with be returned.
+`--no_streaming` | OPTIONAL. Returns only one response and doest not stream the new events.
 
 ## Source File Description
 

--- a/Applications/Examples/EDP/python/market_price_edpgw_authentication.py
+++ b/Applications/Examples/EDP/python/market_price_edpgw_authentication.py
@@ -35,6 +35,8 @@ client_secret = ''
 scope = 'trapi'
 ric = '/TRI.N'
 service = 'ELEKTRON_DD'
+view = []
+no_streaming = False
 
 # Global Variables
 web_socket_app = None
@@ -78,7 +80,12 @@ def send_market_price_request(ric_name):
             'Name': ric_name,
             'Service': service
         },
+        'Streaming': not no_streaming,
     }
+
+    if view:
+        mp_req_json['View'] = view
+
     web_socket_app.send(json.dumps(mp_req_json))
     print("SENT:")
     print(json.dumps(mp_req_json, sort_keys=True, indent=2, separators=(',', ':')))
@@ -229,17 +236,17 @@ if __name__ == "__main__":
     # Get command line parameters
     try:
         opts, args = getopt.getopt(sys.argv[1:], "", ["help", "hostname=", "port=", "app_id=", "user=", "clientid=", "password=",
-                                                      "position=", "auth_url=", "scope=", "ric=", "service="])
+                                                      "position=", "auth_url=", "scope=", "ric=", "service=", "view=", "no_streaming"])
     except getopt.GetoptError:
         print('Usage: market_price_edpgw_authentication.py [--hostname hostname] [--port port] [--app_id app_id] '
               '[--user user] [--clientid clientid] [--password password] [--position position] [--auth_url auth_url] '
-              '[--scope scope] [--ric ric] [--service service] [--help]')
+              '[--scope scope] [--ric ric] [--service service] [--view view] [--no_streaming] [--help]')
         sys.exit(2)
     for opt, arg in opts:
         if opt in "--help":
             print('Usage: market_price_edpgw_authentication.py [--hostname hostname] [--port port] [--app_id app_id] '
                   '[--user user] [--clientid clientid] [--password password] [--position position] [--auth_url auth_url] '
-                  '[--scope scope] [--ric ric] [--service service] [--help]')
+                  '[--scope scope] [--ric ric] [--service service] [--view view] [--no_streaming] [--help]')
             sys.exit(0)
         elif opt in "--hostname":
             hostname = arg
@@ -263,6 +270,10 @@ if __name__ == "__main__":
             ric = arg
         elif opt in "--service":
             service = arg
+        elif opt in "--view":
+            view = arg.split(',')
+        elif opt in "--no_streaming":
+            no_streaming = True
 
     if user == '' or password == '' or  hostname == '' or clientid == '':
         print("user, clientid, password, and hostname are required options")

--- a/Applications/Examples/EDP/python/market_price_edpgw_service_discovery.py
+++ b/Applications/Examples/EDP/python/market_price_edpgw_service_discovery.py
@@ -38,6 +38,8 @@ ric = '/TRI.N'
 service = 'ELEKTRON_DD'
 hostList = []
 hotstandby = False
+view = []
+no_streaming = False
 # Global Variables
 session2 = None
 
@@ -62,7 +64,12 @@ class WebSocketSession:
                 'Name': ric_name,
                 'Service': service
             },
+            'Streaming': not no_streaming,
         }
+
+        if view:
+            mp_req_json['View'] = view
+
         self.web_socket_app.send(json.dumps(mp_req_json))
         print("SENT on " + self.session_name + ":")
         print(json.dumps(mp_req_json, sort_keys=True, indent=2, separators=(',', ':')))
@@ -336,7 +343,8 @@ def get_sts_token(current_refresh_token, url=None):
 def print_commandline_usage_and_exit(exit_code):
     print('Usage: market_price_edpgw_service_discovery.py [--app_id app_id] '
           '[--user user] [--clientid clientid] [--password password] [--position position] [--auth_url auth_url] '
-          '[--discovery_url discovery_url] [--scope scope] [--service service] [--region region] [--ric ric] [--hotstandby] [--help]')
+          '[--discovery_url discovery_url] [--scope scope] [--service service] [--region region] [--ric ric] [--hotstandby] '
+          '[--view view] [--no_streaming] [--help]')
     sys.exit(exit_code)
 
 
@@ -346,7 +354,7 @@ if __name__ == "__main__":
     try:
         opts, args = getopt.getopt(sys.argv[1:], "", ["help", "app_id=", "user=", "clientid=", "password=",
                                                       "position=", "auth_url=", "discovery_url=", "scope=", "service=", "region=", "ric=",
-                                                      "hotstandby"])
+                                                      "hotstandby", "view=", "no_streaming"])
     except getopt.GetoptError:
         print_commandline_usage_and_exit(2)
     for opt, arg in opts:
@@ -376,9 +384,13 @@ if __name__ == "__main__":
                 print("Unknown region \"" + region + "\". The region must be either \"amer\", \"emea\", or \"apac\".")
                 sys.exit(1)
         elif opt in "--ric":
-            ric = arg
+            ric = arg.split(',')
         elif opt in "--hotstandby":
-                hotstandby = True
+            hotstandby = True
+        elif opt in "--view":
+            view = arg.split(',')
+        elif opt in "--no_streaming":
+            no_streaming = True
 
     if user == '' or password == '' or clientid == '':
         print("user, clientid and password are required options")


### PR DESCRIPTION
I have created some new options and refactored the --ric one. They helped me to test the Elektron. I am sharing if this would be useful for you.

For --ric, if you pass a list of rics separated by comma (,), it will split all of them and send to Elektron.

I have created a --view option, so now it is possible to pass a list of fields to get, and the --no_streaming if you don't want to receive the updates.