### PR TITLE
C# MarketPriceAuthEx: Longer help screen, and add --help option

### DIFF
--- a/Applications/Examples/CSharp/MarketPriceAuthenticationExample.cs
+++ b/Applications/Examples/CSharp/MarketPriceAuthenticationExample.cs
@@ -275,7 +275,7 @@ namespace MarketPriceAuthenticationExample
                         if (i + 1 >= args.Length)
                         {
                             Console.WriteLine("{0} requires an argument.", args[i]);
-                            printCommandLineUsageAndExit();
+                            printCommandLineUsageAndExit(1);
                         }
                         _appId = args[i + 1];
                         ++i;
@@ -285,7 +285,7 @@ namespace MarketPriceAuthenticationExample
                         if (i + 1 >= args.Length)
                         {
                             Console.WriteLine("{0} requires an argument.", args[i]);
-                            printCommandLineUsageAndExit();
+                            printCommandLineUsageAndExit(1);
                         }
                         _authHostName = args[i + 1];
                         ++i;
@@ -295,7 +295,7 @@ namespace MarketPriceAuthenticationExample
                         if (i + 1 >= args.Length)
                         {
                             Console.WriteLine("{0} requires an argument.", args[i]);
-                            printCommandLineUsageAndExit();
+                            printCommandLineUsageAndExit(1);
                         }
                         _authPort = args[i + 1];
                         ++i;
@@ -306,7 +306,7 @@ namespace MarketPriceAuthenticationExample
                         if (i + 1 >= args.Length)
                         {
                             Console.WriteLine("{0} requires an argument.", args[i]);
-                            printCommandLineUsageAndExit();
+                            printCommandLineUsageAndExit(1);
                         }
                         _hostName = args[i + 1];
                         ++i;
@@ -317,7 +317,7 @@ namespace MarketPriceAuthenticationExample
                         if (i + 1 >= args.Length)
                         {
                             Console.WriteLine("{0} requires an argument.", args[i]);
-                            printCommandLineUsageAndExit();
+                            printCommandLineUsageAndExit(1);
                         }
                         _port = args[i + 1];
                         ++i;
@@ -328,7 +328,7 @@ namespace MarketPriceAuthenticationExample
                         if (i + 1 >= args.Length)
                         {
                             Console.WriteLine("{0} requires an argument.", args[i]);
-                            printCommandLineUsageAndExit();
+                            printCommandLineUsageAndExit(1);
                         }
                         _userName = args[i + 1];
                         ++i;
@@ -338,15 +338,19 @@ namespace MarketPriceAuthenticationExample
                         if (i + 1 >= args.Length)
                         {
                             Console.WriteLine("{0} requires an argument.", args[i]);
-                            printCommandLineUsageAndExit();
+                            printCommandLineUsageAndExit(1);
                         }
                         _password = args[i + 1];
                         ++i;
                         break;
 
+                    case "--help":
+                        printCommandLineUsageAndExit(0);
+                        break;
+
                     default:
                         Console.WriteLine("Unknown option: {0}", args[i]);
-                        printCommandLineUsageAndExit();
+                        printCommandLineUsageAndExit(1);
                         break;
 
                 }
@@ -358,10 +362,20 @@ namespace MarketPriceAuthenticationExample
         }
 
         /// <summary>Prints usage information. Used when arguments cannot be parsed.</summary>
-        void printCommandLineUsageAndExit()
+        void printCommandLineUsageAndExit(int exitStatus)
         {
-            Console.WriteLine("Usage: {0} [ -h hostname ] [-p port] [-a appID] [-u user] [--password password] [--auth_hostname hostname] [--auth_port port]", System.AppDomain.CurrentDomain.FriendlyName);
-            Environment.Exit(1);
+            Console.WriteLine("Usage:\n" +
+                "dotnet {0}.dll\n" +
+                "   [-h|--hostname <hostname>]  \n" +
+                "   [-p|--port <port>]          \n" +
+                "   [-a|--app_id <appId>]       \n" +
+                "   [-u|--user <user>]          # Your Refinitiv Elektron username\n" +
+                "   [--password <password>]     # Your Refinitiv Elektron password\n" +
+                "   [--auth_hostname <host>]    # Hostname for the Refinitiv Elektron authentication service\n" +
+                "   [--auth_port <port>]        # Port for the Refinitiv Elektron authentication service\n" +
+                "   [--help]                    # Display this help screen and exit\n",
+                System.AppDomain.CurrentDomain.FriendlyName);
+            Environment.Exit(exitStatus);
         }
     }
 }


### PR DESCRIPTION
What do you think about a longer, more descriptive help screen, and a `--help` option to allow users to explicitly access it without causing a failed process run? (Running the `--help` option in this PR results in a successful exit status.)

I think this form of the help screen is more readable, because the old version ends up wrapping the long list of options across multiple lines. It also includes descriptions for some of the options that might be ambiguous or non-obvious.

And the old version left out some of the alternate calling forms for options that have both short and long forms, like `-h`/`--hostname`.

Also, in help screens, it's conventional to put values that the user is supposed to replace with their own text in `<...>` angle brackets. This PR does that.

Also, the old version of the help screen describes `System.AppDomain.CurrentDomain.FriendlyName` as a command you can directly run from the command line. That doesn't work; in .NET Core, the compiled program is a DLL that you need to run with the `dotnet` command. This PR corrects the help screen to reflect that.