### PR TITLE
C# MPEGSDE: bump Newtonsoft.Json to non-beta version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 node_modules/
 .DS_Store
 xcuserdata/*
+.vs
+packages/
+obj/

--- a/Applications/Examples/EDP/CSharp/MarketPriceEdpGwServiceDiscoveryExample/MarketPriceEdpGwServiceDiscoveryExample.csproj
+++ b/Applications/Examples/EDP/CSharp/MarketPriceEdpGwServiceDiscoveryExample/MarketPriceEdpGwServiceDiscoveryExample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1-beta1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Your MarketPriceEdpGwServiceDiscoveryExample example is using a beta version of the Newtonsoft.Json library. How about bumping it to a non-beta version? You probably want end users to not be using beta software either when evaluating your service or running production code.