### PR TITLE
.gitignore: Add stuff for working with Visual Studio and NuGet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 node_modules/
 .DS_Store
 xcuserdata/*
+.vs
+packages/
+obj/


### PR DESCRIPTION
When working with this code in Visual Studio and NuGet, it creates some temp directories that are not covered by your current `.gitignore`, and should not be checked in to the repo. How about adding them to `.gitignore`?