### PR TITLE
C#: MPEGAE/MPEGSDE: Represent host/port endpoints as object instead of tuple

### DIFF
--- a/Applications/Examples/EDP/CSharp/MarketPriceEdpGwAuthenticationExample/MarketPriceEdpGwAuthenticationExample.cs
+++ b/Applications/Examples/EDP/CSharp/MarketPriceEdpGwAuthenticationExample/MarketPriceEdpGwAuthenticationExample.cs
@@ -17,6 +17,19 @@ using Newtonsoft.Json.Linq;
 
 namespace MarketPriceEdpGwAuthenticationExample
 {
+    /// <summary>
+    /// A host/port endpoint for connecting a service or socket.
+    /// </summary>
+    class Endpoint
+    {
+        public string Host { get; set; }
+        public int Port { get; set; } = -999;
+        public override string ToString()
+        {
+            return Host + ":" + Port;
+        }
+    }
+
     class MarketPriceEdpGwAuthenticationExample
     {
         /// <summary>The websocket used for retrieving market content.</summary>
@@ -29,11 +42,8 @@ namespace MarketPriceEdpGwAuthenticationExample
         private string _authToken;
         private string _refreshToken;
 
-        /// <summary>The configured hostname of the Websocket server.</summary>
-        private string _hostName;
-
-        /// <summary>The configured port used when opening the WebSocket.</summary>
-        private string _port = "443";
+        /// <summary>The endpoint to connect the Websocket server to.</summary>
+        private Endpoint _endpoint = new Endpoint() { Port = 443 };
 
         /// <summary>The full URL of the authentication server. If not specified,
         /// https://api.refinitiv.com:443/auth/oauth2/beta1/token is used.</summary>
@@ -205,7 +215,7 @@ namespace MarketPriceEdpGwAuthenticationExample
             _position = (hostEntry == null) ? "127.0.0.1/net" : hostEntry.ToString();
 
             /* Open a websocket. */
-            Uri uri = new Uri("wss://" + _hostName + ":" + _port + "/WebSocket");
+            Uri uri = new Uri("wss://" + _endpoint.Host + ":" + _endpoint.Port + "/WebSocket");
             Console.WriteLine("Connecting to WebSocket " + uri.AbsoluteUri + " ...");
 
             if (!GetAuthenticationInfo(false))
@@ -439,13 +449,13 @@ namespace MarketPriceEdpGwAuthenticationExample
                         _authUrl = args[++i];
                         break;
                     case "--hostname":
-                        _hostName = args[++i];
+                        _endpoint.Host = args[++i];
                         break;
                     case "--password":
                         _password = args[++i];
                         break;
                     case "--port":
-                        _port = args[++i];
+                        _endpoint.Port = Int32.Parse(args[++i]);
                         break;
                     case "--ric":
                         _ric = args[++i];
@@ -475,7 +485,7 @@ namespace MarketPriceEdpGwAuthenticationExample
                 PrintCommandLineUsageAndExit();
             }
 
-            if (_hostName == null)
+            if (_endpoint.Host == null)
             {
                 Console.WriteLine("hostname must be specified on the command line");
                 PrintCommandLineUsageAndExit();

--- a/Applications/Examples/EDP/CSharp/MarketPriceEdpGwServiceDiscoveryExample/MarketPriceEdpGwServiceDiscoveryExample.cs
+++ b/Applications/Examples/EDP/CSharp/MarketPriceEdpGwServiceDiscoveryExample/MarketPriceEdpGwServiceDiscoveryExample.cs
@@ -38,6 +38,19 @@ using Newtonsoft.Json.Linq;
 
 namespace MarketPriceEdpGwServiceDiscoveryExample
 {
+    /// <summary>
+    /// A host/port endpoint for connecting a service or socket.
+    /// </summary>
+    class Endpoint
+    {
+        public string Host { get; set; }
+        public int Port { get; set; } = -999;
+        public override string ToString()
+        {
+            return Host + ":" + Port;
+        }
+    }
+
     class MarketPriceEdpGwServiceDiscoveryExample
     {
         /// <summary>The websocket(s) used for retrieving market content.</summary>
@@ -89,7 +102,7 @@ namespace MarketPriceEdpGwServiceDiscoveryExample
         private static string _region = "amer";
 
         /// <summary>hosts returned by service discovery</summary>
-        private static List<Tuple<string,string>> _hosts = new List<Tuple<string, string>>();
+        private static List<Endpoint> _hosts = new List<Endpoint>();
 
         /// <summary> Specifies buffer size for each read from WebSocket.</summary>
         private static readonly int BUFFER_SIZE = 8192;
@@ -114,7 +127,7 @@ namespace MarketPriceEdpGwServiceDiscoveryExample
             /// <summary> URI to connect the WebSocket to. </summary>
             private Uri _uri;
 
-            public WebSocketSession(String name, String host, String port)
+            public WebSocketSession(String name, String host, int port)
             {
                 Name = name;
                 _uri = new Uri("wss://" + host + ":" + port + "/WebSocket");
@@ -492,12 +505,20 @@ namespace MarketPriceEdpGwServiceDiscoveryExample
 
                         if (_hotstandby && locations.Count == 1)
                         {
-                            _hosts.Add(new Tuple<string,string>((endpoints[i]["endpoint"]).ToString(),(endpoints[i]["port"]).ToString()));
+                            _hosts.Add(new Endpoint
+                            {
+                                Host = (endpoints[i]["endpoint"]).ToString(),
+                                Port = Int32.Parse((endpoints[i]["port"]).ToString())
+                            });
                             continue;
                         }
                         if (!_hotstandby && locations.Count == 2)
                         {
-                            _hosts.Add(new Tuple<string, string>((endpoints[i]["endpoint"]).ToString(),(endpoints[i]["port"]).ToString()));
+                            _hosts.Add(new Endpoint
+                            {
+                                Host = (endpoints[i]["endpoint"]).ToString(),
+                                Port = Int32.Parse((endpoints[i]["port"]).ToString())
+                            });
                             continue;
                         }
                     }
@@ -599,7 +620,7 @@ namespace MarketPriceEdpGwServiceDiscoveryExample
             /* Open websocket(s) */
             foreach (var host in _hosts)
             {
-                var webSocketSession = new WebSocketSession("Session" + (_webSocketSessions.Count + 1), host.Item1, host.Item2);
+                var webSocketSession = new WebSocketSession("Session" + (_webSocketSessions.Count + 1), host.Host, host.Port);
                 _webSocketSessions.Add(webSocketSession.Name, webSocketSession);
 
                 Task.Factory.StartNew(() =>


### PR DESCRIPTION
Tuple is not a great data structure for representing host/port pair endpoints. Tuple is good for when you don't know the type, arity, or significance of the member items at compile time. But in case, we do know: they're always host and port.

This PR switches a couple of the C# examples to represent host/port pairs as objects instead of Tuples. I think this improves readability of the code, even (and maybe especially) for beginner programmers. Especially at the point of reading values back out of the structure: now it says `host.Host` and `host.Port` instead of accessing the tuple members by index, which requires the reader to know the order of the items in the tuple (and it's not clear at the call point where they should go to look for that information; when using an object, they can just go to the type definition using their editor's code navigation feature).

This PR also represents Port as an int instead of a string, since it's a numeric value. This will give you fail-fast behavior when someone passes a bogus string as a port value on the command line, which will make user errors easier to diagnose.